### PR TITLE
Use require instead of require_relative for native extension

### DIFF
--- a/lib/json_escape.rb
+++ b/lib/json_escape.rb
@@ -19,7 +19,7 @@ module JsonEscape
   end
 
   begin
-    require_relative "json_escape/json_escape"
+    require "json_escape/json_escape"
   rescue LoadError
     include Pure
   end


### PR DESCRIPTION
RubyGems is changing `install_extension_in_lib` to default to false (https://github.com/ruby/rubygems/pull/9240), meaning native extensions will no longer be installed into `lib/`. `require_relative` won't be able to find the shared object, but `require` will since RubyGems adds the extension directory to the load path.